### PR TITLE
Fix README link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../Readme.md")]
+#![doc = include_str!("../README.md")]
 #![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
 // TODO: ark-circom and ethers-core pull in a lot of dependencies, some duplicate.
 #![allow(clippy::multiple_crate_versions)]


### PR DESCRIPTION
Without this the build fails for me:

```
error: couldn't read src/../Readme.md: No such file or directory (os error 2)
 --> src/lib.rs:1:10
  |
1 | #![doc = include_str!("../Readme.md")]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```