### PR TITLE
chore: update semaphore submodule to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "semaphore"]
 	path = semaphore
-	url = git@github.com:appliedzkp/semaphore.git
+	url = https://github.com/appliedzkp/semaphore.git


### PR DESCRIPTION
Without this CI such as Github action will fail. E.g.:

```
 error: failed to get `semaphore` as a dependency of package `rln v0.1.0 (/home/runner/work/zerokit/zerokit/rln)`

Caused by:
  failed to load source for dependency `semaphore`

Caused by:
  Unable to update https://github.com/oskarth/semaphore-rs

Caused by:
  failed to update submodule `semaphore`

Caused by:
  failed to fetch submodule `semaphore` from git@github.com:appliedzkp/semaphore.git

Caused by:
  failed to authenticate when downloading repository

  * attempted ssh-agent authentication, but no usernames succeeded: `git`

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  error authenticating: no auth sock variable; class=Ssh (23)
Error: Process completed with exit code 101.
```

Related: https://github.blog/2021-09-01-improving-git-protocol-security-github/