### PR TITLE
fix(semaphore-rs): fix U256 data type origin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ hex = "0.4.0"
 hex-literal = "0.3"
 num-bigint = { version = "0.4", default-features = false, features = ["rand"] }
 once_cell = "1.8"
-primitive-types = "0.11.1"
 proptest = { version = "1.0", optional = true }
 rand = "0.8.4"
 rayon = "1.5.1"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -15,7 +15,7 @@ use ark_groth16::{
 use ark_relations::r1cs::SynthesisError;
 use ark_std::UniformRand;
 use color_eyre::Result;
-use primitive_types::U256;
+use ethers_core::types::U256;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use std::time::Instant;


### PR DESCRIPTION
Recent updates to `ethers-core` broke compilation of `semaphore-rs`. Compilation results broken due to no revision hardcoded for `ark-circom`'s `ethers-core` dependency (which, in turn, is a dependency of `semaphore-rs` too), hence latest master will be used at each new compilation.

The reasons of the failure seems to be related with a refactoring of the U256 data type, which before was in `primitive_types::U256` and now is moved to (the updated) `ethers_core::types::U256`. 

This PR updates the reference to the `U256` data type to the refactored one now contained in `ethers_core` and removes the previous dependency `primitive_types`.

Note that a solution to this problem is a requirement for all those projects that use `semaphore-rs` as dependency, since their compilation is now failing.

@recmo @philsippl 