### PR TITLE
add a missing clone implementation for derived trees

### DIFF
--- a/src/lazy_merkle_tree.rs
+++ b/src/lazy_merkle_tree.rs
@@ -137,6 +137,15 @@ impl<H: Hasher> LazyMerkleTree<H, Canonical> {
     }
 }
 
+impl<H: Hasher> Clone for LazyMerkleTree<H, Derived> {
+    fn clone(&self) -> Self {
+        Self {
+            tree:     self.tree.clone(),
+            _version: Derived,
+        }
+    }
+}
+
 enum AnyTree<H: Hasher> {
     Empty(EmptyTree<H>),
     Sparse(SparseTree<H>),


### PR DESCRIPTION
There's a place where I need it and there's nothing semantically wrong in cloning it (compared to `Canonical`)