### PR TITLE
Make the fields of `Proof` public

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -28,7 +28,7 @@ fn seed_hex(seed: &[u8]) -> [u8; 64] {
 
 impl Identity {
     #[must_use]
-    #[deprecated(since="0.2.0", note="please use `from_secret` instead")]
+    #[deprecated(since = "0.2.0", note = "please use `from_secret` instead")]
     pub fn from_seed(seed: &[u8]) -> Self {
         let seed_hex = seed_hex(seed);
         Self {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,7 +6,7 @@ use crate::{
     poseidon_tree::PoseidonHash,
     Field,
 };
-use ark_bn254::{Bn254, Fr, Parameters};
+use ark_bn254::{Bn254, Parameters};
 use ark_circom::CircomReduction;
 use ark_ec::bn::Bn;
 use ark_groth16::{
@@ -29,7 +29,7 @@ pub type G2 = ([U256; 2], [U256; 2]);
 
 /// Wrap a proof object so we have serde support
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Proof(G1, G2, G1);
+pub struct Proof(pub G1, pub G2, pub G1);
 
 impl From<ArkProof<Bn<Parameters>>> for Proof {
     fn from(proof: ArkProof<Bn<Parameters>>) -> Self {
@@ -201,7 +201,7 @@ pub fn verify_proof(
 
     let public_inputs = [root, nullifier_hash, signal_hash, external_nullifier_hash]
         .iter()
-        .map(Fr::try_from)
+        .map(ark_bn254::Fr::try_from)
         .collect::<Result<Vec<_>, _>>()?;
 
     let ark_proof = (*proof).into();


### PR DESCRIPTION
This is necessary for converting the proof to types that `ethers-rs` can work with. Alternatively I could add a `From` impl, but this would involve adding `ethers` as a dependency which seems silly to me. 