### PR TITLE
Add private fetches for Merkle proofs using Blyss

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ dylib = ["wasmer/dylib", "wasmer-engine-dylib", "wasmer-compiler-cranelift"]
 depth_16 = ["semaphore-depth-config/depth_16", "semaphore-depth-macros/depth_16"]
 depth_20 = ["semaphore-depth-config/depth_20", "semaphore-depth-macros/depth_20"]
 depth_30 = ["semaphore-depth-config/depth_30", "semaphore-depth-macros/depth_30"]
+private_fetch = ["blyss-rs", "tokio"]
 
 [[bench]]
 name = "criterion"
@@ -56,6 +57,8 @@ thiserror = "1.0.0"
 tiny-keccak = { version = "2.0.2" }
 wasmer = { version = "2.0" }
 semaphore-depth-macros = { path = "crates/semaphore-depth-macros" }
+blyss-rs = { optional = true, version = "0.2.0" }
+tokio = { optional = true, version = "1", features = ["macros"] }
 
 # Use the same `ethers-core` version as ark-circom
 # TODO: Remove


### PR DESCRIPTION
This PR adds the ability to privately fetch Merkle proofs using homomorphic encryption. The underlying service that actually serves the proofs is called [Blyss](https://blyss.dev). 

The cool part is that the server *cannot learn anything* about which Merkle proof is being fetched. It's fairly efficient: 128 KB of download and ~2 seconds. The test in this PR uses the Blyss service, but the server can also be self-hosted. 

This is just a draft, since still figuring out if this repo is the best place to put this functionality. CC @philsippl 