### PR TITLE
Save tree state in a memory mapped file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tiny-keccak = { version = "2.0.2" }
 wasmer = { version = "2.0" }
 semaphore-depth-macros = { path = "crates/semaphore-depth-macros" }
 mmap-rs = "0.5.0"
+bincode = "1.3.3"
 
 # Use the same `ethers-core` version as ark-circom
 # TODO: Remove

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ thiserror = "1.0.0"
 tiny-keccak = { version = "2.0.2" }
 wasmer = { version = "2.0" }
 semaphore-depth-macros = { path = "crates/semaphore-depth-macros" }
+mmap-rs = "0.5.0"
 
 # Use the same `ethers-core` version as ark-circom
 # TODO: Remove

--- a/src/lazy_merkle_tree.rs
+++ b/src/lazy_merkle_tree.rs
@@ -841,7 +841,7 @@ impl<H: Hasher> DenseTreeMMap<H> {
                 Err(_e) => return Err("failed to create a file")
             };
 
-        let size_of_hasher = std::mem::size_of::<H>();
+        let size_of_hasher = std::mem::size_of::<H::Hash>();
         
         let leaf_count = 1 << depth;
         let first_leaf_index = 1 << depth;

--- a/src/lazy_merkle_tree.rs
+++ b/src/lazy_merkle_tree.rs
@@ -7,7 +7,6 @@ use std::{fs::OpenOptions, path::PathBuf, str::FromStr};
 
 use bincode::{deserialize, serialize};
 use mmap_rs::{MmapMut, MmapOptions};
-use hex_literal::hex;
 
 pub trait VersionMarker {}
 #[derive(Debug)]
@@ -99,19 +98,21 @@ impl<H: Hasher, Version: VersionMarker> LazyMerkleTree<H, Version> {
         }
     }
 
+    // TODO: Return some proper errors
+    /// Attempts to restore previous tree state from memory mapped file
     #[must_use]
     pub fn attempt_dense_mmap_restore(
         empty_leaf: &H::Hash,
         depth: usize,
         file_path: &str,
-    ) -> LazyMerkleTree<H, Canonical> {
-        LazyMerkleTree { 
+    ) -> Result<LazyMerkleTree<H, Canonical>, &'static str> {
+        Ok(LazyMerkleTree { 
             tree: match AnyTree::try_restore_dense_mmap_tree_state(empty_leaf, depth, file_path) {
                 Ok(tree) => tree,
-                Err(_e) => EmptyTree::new(0, empty_leaf.clone()).into()
+                Err(e) => return Err(e)
             },
             _version: Canonical 
-        }
+        })
     }
 
     /// Returns the depth of the tree.

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -5,7 +5,7 @@
 //! * Disk based storage backend (using mmaped files should be easy)
 
 use crate::Field;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{
     fmt::Debug,
     iter::{once, repeat, successors},
@@ -14,7 +14,7 @@ use std::{
 /// Hash types, values and algorithms for a Merkle tree
 pub trait Hasher {
     /// Type of the leaf and node hashes
-    type Hash: Clone + Eq + Serialize + Debug;
+    type Hash: Clone + Eq + Serialize + DeserializeOwned + Debug;
 
     /// Compute the hash of an intermediate node
     fn hash_node(left: &Self::Hash, right: &Self::Hash) -> Self::Hash;

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -5,7 +5,7 @@
 //! * Disk based storage backend (using mmaped files should be easy)
 
 use crate::Field;
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     fmt::Debug,
     iter::{once, repeat, successors},


### PR DESCRIPTION
This PR adds new type of tree - dense memory mapped tree.

It is pretty much the same logic as for dense tree, except there is an added func that attempts a restore.
My idea is to return a Result, and on failed restore and just build a new tree, but that is left to the crate user.

The Hasher trait now has DeserializeOwned requirement, which i presume is not an issue