### PR TITLE
Add auth flow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,8 @@ mod test {
             signal_hash,
             external_nullifier_hash,
             &proof,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(success);
     }
 

--- a/src/protocol/authentication.rs
+++ b/src/protocol/authentication.rs
@@ -1,0 +1,37 @@
+use crate::identity::Identity;
+use crate::poseidon_tree::LazyPoseidonTree;
+use crate::protocol::{Proof, ProofError};
+use crate::Field;
+
+pub fn generate_proof(
+    depth: usize,
+    identity: &Identity,
+    ext_nullifier_hash: Field,
+    signal_hash: Field,
+) -> Result<Proof, ProofError> {
+    let merkle_proof = LazyPoseidonTree::new(depth, Field::from(0))
+        .update(0, &identity.commitment())
+        .proof(0);
+    return super::generate_proof(identity, &merkle_proof, ext_nullifier_hash, signal_hash);
+}
+
+pub fn verify_proof(
+    depth: usize,
+    id_commitment: Field,
+    nullifier_hash: Field,
+    signal_hash: Field,
+    ext_nullifier_hash: Field,
+    proof: &Proof,
+) -> Result<bool, ProofError> {
+    let root = LazyPoseidonTree::new(depth, Field::from(0))
+        .update(0, &id_commitment)
+        .root();
+    return super::verify_proof(
+        root,
+        nullifier_hash,
+        signal_hash,
+        ext_nullifier_hash,
+        proof,
+        depth,
+    );
+}

--- a/src/protocol/authentication.rs
+++ b/src/protocol/authentication.rs
@@ -1,7 +1,9 @@
-use crate::identity::Identity;
-use crate::poseidon_tree::LazyPoseidonTree;
-use crate::protocol::{Proof, ProofError};
-use crate::Field;
+use crate::{
+    identity::Identity,
+    poseidon_tree::LazyPoseidonTree,
+    protocol::{Proof, ProofError},
+    Field,
+};
 
 pub fn generate_proof(
     depth: usize,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -45,8 +45,8 @@ impl From<Proof> for ArkProof<Bn<Parameters>> {
     fn from(proof: Proof) -> Self {
         let eth_proof = ark_circom::ethereum::Proof {
             a: ark_circom::ethereum::G1 {
-                x: proof.0.0,
-                y: proof.0.1,
+                x: proof.0 .0,
+                y: proof.0 .1,
             },
             #[rustfmt::skip] // Rustfmt inserts some confusing spaces
             b: ark_circom::ethereum::G2 {
@@ -55,8 +55,8 @@ impl From<Proof> for ArkProof<Bn<Parameters>> {
                 y: [proof.1.1[1], proof.1.1[0]],
             },
             c: ark_circom::ethereum::G1 {
-                x: proof.2.0,
-                y: proof.2.1,
+                x: proof.2 .0,
+                y: proof.2 .1,
             },
         };
         eth_proof.into()
@@ -250,7 +250,7 @@ mod test {
             signal_hash,
             &mut rng,
         )
-            .unwrap()
+        .unwrap()
     }
 
     #[test_all_depths]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -21,6 +21,8 @@ use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use thiserror::Error;
 
+pub mod authentication;
+
 // Matches the private G1Tup type in ark-circom.
 pub type G1 = (U256, U256);
 
@@ -43,8 +45,8 @@ impl From<Proof> for ArkProof<Bn<Parameters>> {
     fn from(proof: Proof) -> Self {
         let eth_proof = ark_circom::ethereum::Proof {
             a: ark_circom::ethereum::G1 {
-                x: proof.0 .0,
-                y: proof.0 .1,
+                x: proof.0.0,
+                y: proof.0.1,
             },
             #[rustfmt::skip] // Rustfmt inserts some confusing spaces
             b: ark_circom::ethereum::G2 {
@@ -53,8 +55,8 @@ impl From<Proof> for ArkProof<Bn<Parameters>> {
                 y: [proof.1.1[1], proof.1.1[0]],
             },
             c: ark_circom::ethereum::G1 {
-                x: proof.2 .0,
-                y: proof.2 .1,
+                x: proof.2.0,
+                y: proof.2.1,
             },
         };
         eth_proof.into()
@@ -248,7 +250,7 @@ mod test {
             signal_hash,
             &mut rng,
         )
-        .unwrap()
+            .unwrap()
     }
 
     #[test_all_depths]


### PR DESCRIPTION
Adds a version of this protocol allowing users to prove the knowledge of identity commitment preimage (such that the commitment becomes a public input – use carefully).