### PR TITLE
Added code for generating random identity, not from seed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub type EthereumGroth16Proof = ark_circom::ethereum::Proof;
 mod test {
     use crate::{
         hash_to_field,
-        identity::Identity,
+        identity::{self, Identity},
         poseidon_tree::LazyPoseidonTree,
         protocol,
         protocol::{generate_nullifier_hash, generate_proof, verify_proof},
@@ -48,6 +48,18 @@ mod test {
         let serialized = serde_json::to_value(value).unwrap();
         let deserialized = serde_json::from_value(serialized).unwrap();
         assert_eq!(value, deserialized);
+    }
+
+    #[test]
+    fn test_random_identity() {
+        // create identity-1
+        let identity_1 = Identity::random();
+
+        // create identity-2
+        let identity_2 = Identity::random();
+
+        // ensure they are different
+        assert_ne!(identity_1.secret_hash(), identity_2.secret_hash());
     }
 
     fn test_end_to_end(
@@ -145,8 +157,11 @@ mod test {
 #[cfg(feature = "bench")]
 pub mod bench {
     use crate::{
-        hash_to_field, identity::Identity, poseidon_tree::LazyPoseidonTree,
-        protocol::{generate_proof, generate_witness}, Field,
+        hash_to_field,
+        identity::Identity,
+        poseidon_tree::LazyPoseidonTree,
+        protocol::{generate_proof, generate_witness},
+        Field,
     };
     use criterion::Criterion;
     use semaphore_depth_config::get_supported_depths;
@@ -182,18 +197,18 @@ pub mod bench {
 
     fn bench_witness(criterion: &mut Criterion, depth: usize) {
         let leaf = Field::from(0);
-    
+
         // Create tree
         let mut hello = *b"hello";
         let id = Identity::from_secret(&mut hello, None);
         let mut tree = LazyPoseidonTree::new(depth, leaf).derived();
         tree = tree.update(0, &id.commitment());
         let merkle_proof = tree.proof(0);
-    
+
         // change signal and external_nullifier here
         let signal_hash = hash_to_field(b"xxx");
         let external_nullifier_hash = hash_to_field(b"appId");
-    
+
         criterion.bench_function(&format!("witness_{depth}"), move |b| {
             b.iter(|| {
                 generate_witness(&id, &merkle_proof, external_nullifier_hash, signal_hash).unwrap();


### PR DESCRIPTION
## Motivation

Developing a method to assign unique IDs (commitments) to users and securely manage their identity secrets (trapdoor & nullifier) in a custodial setup.

## Solution

1. Generate a random number.
2. Convert this number to a string.
3. Transform the string to bytes.
4. Shape these bytes into a fixed-length array for `Identity::from_secret()`.