### PR TITLE
Derived Deserialize for Proof using associated type bound

### DIFF
--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -46,7 +46,8 @@ pub enum Branch<H: Hasher> {
 }
 
 /// Merkle proof path, bottom to top.
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(deserialize = "H::Hash: Deserialize<'de>",))]
 pub struct Proof<H: Hasher>(pub Vec<Branch<H>>);
 
 /// For a given node index, return the parent node index


### PR DESCRIPTION
This is useful for creating a signup-sequencer client so we can properly deserialize some responses.