### PR TITLE
Specify exact ruint version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 authors = [
     "Remco Bloemen <remco@worldcoin.org>",
-    "Philipp Sippl <philipp@worldcoin.org>"]
+    "Philipp Sippl <philipp@worldcoin.org>",
+]
 homepage = "https://github.com/worldcoin/semaphore-rs"
 repository = "https://github.com/worldcoin/semaphore-rs"
 description = "Rust support library for Semaphore"
@@ -20,9 +21,18 @@ members = ["crates/*"]
 default = []
 bench = ["criterion", "proptest"]
 dylib = ["wasmer/dylib", "wasmer-engine-dylib", "wasmer-compiler-cranelift"]
-depth_16 = ["semaphore-depth-config/depth_16", "semaphore-depth-macros/depth_16"]
-depth_20 = ["semaphore-depth-config/depth_20", "semaphore-depth-macros/depth_20"]
-depth_30 = ["semaphore-depth-config/depth_30", "semaphore-depth-macros/depth_30"]
+depth_16 = [
+    "semaphore-depth-config/depth_16",
+    "semaphore-depth-macros/depth_16",
+]
+depth_20 = [
+    "semaphore-depth-config/depth_20",
+    "semaphore-depth-macros/depth_20",
+]
+depth_30 = [
+    "semaphore-depth-config/depth_30",
+    "semaphore-depth-macros/depth_30",
+]
 
 [[bench]]
 name = "criterion"
@@ -32,12 +42,23 @@ required-features = ["bench", "proptest"]
 
 [dependencies]
 ark-bn254 = { version = "0.3.0" }
-ark-circom = { git = "https://github.com/gakonst/ark-circom", rev = "a93c8b0", features = ["circom-2"] }
-ark-ec = { version = "0.3.0", default-features = false, features = ["parallel"] }
-ark-ff = { version = "0.3.0", default-features = false, features = ["parallel", "asm"] }
-ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", rev = "765817f", features = ["parallel"] }
+ark-circom = { git = "https://github.com/gakonst/ark-circom", rev = "a93c8b0", features = [
+    "circom-2",
+] }
+ark-ec = { version = "0.3.0", default-features = false, features = [
+    "parallel",
+] }
+ark-ff = { version = "0.3.0", default-features = false, features = [
+    "parallel",
+    "asm",
+] }
+ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", rev = "765817f", features = [
+    "parallel",
+] }
 ark-relations = { version = "0.3.0", default-features = false }
-ark-std = { version = "0.3.0", default-features = false, features = ["parallel"] }
+ark-std = { version = "0.3.0", default-features = false, features = [
+    "parallel",
+] }
 color-eyre = "0.6"
 criterion = { version = "0.3", optional = true, features = ["async_tokio"] }
 hex = "0.4.0"
@@ -47,7 +68,7 @@ once_cell = "1.8"
 proptest = { version = "1.0", optional = true }
 rand = "0.8.4"
 rayon = "1.5.1"
-ruint = { version = "1.2.0", features = ["serde", "num-bigint", "ark-ff"] }
+ruint = { version = "=1.11.0", features = ["serde", "num-bigint", "ark-ff"] }
 semaphore-depth-config = { path = "crates/semaphore-depth-config" }
 serde = "1.0"
 sha2 = "0.10.1"

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     poseidon_tree::PoseidonHash,
     Field,
 };
-use ark_bn254::{Bn254, Parameters, FrParameters};
+use ark_bn254::{Bn254, FrParameters, Parameters};
 use ark_circom::CircomReduction;
 use ark_ec::bn::Bn;
 use ark_ff::Fp256;
@@ -19,7 +19,6 @@ use color_eyre::Result;
 use ethers_core::types::U256;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
-use std::time::Instant;
 use thiserror::Error;
 
 pub mod authentication;
@@ -145,7 +144,8 @@ fn generate_proof_rs(
     s: ark_bn254::Fr,
 ) -> Result<Proof, ProofError> {
     let depth = merkle_proof.0.len();
-    let full_assignment = generate_witness(identity, merkle_proof, external_nullifier_hash, signal_hash)?;
+    let full_assignment =
+        generate_witness(identity, merkle_proof, external_nullifier_hash, signal_hash)?;
 
     let zkey = zkey(depth);
     let ark_proof = create_proof_with_reduction_and_matrices::<_, CircomReduction>(


### PR DESCRIPTION
It appears there's a bug in ruint in the `uint!` macro. Until there is a fix we can specify an exact version.