### PR TITLE
Multithreading Dense Merkle Tree Initialization

### DIFF
--- a/crates/semaphore-depth-macros/src/lib.rs
+++ b/crates/semaphore-depth-macros/src/lib.rs
@@ -27,11 +27,13 @@ use syn::{
 ///     assert!(depth > 0);
 /// }
 ///
+/// # #[no_run]
 /// #[test]
 /// fn test_depth_non_zero_depth_16() {
 ///     test_depth_non_zero(16);
 /// }
 ///
+/// # #[no_run]
 /// #[test]
 /// fn test_depth_non_zero_depth_30() {
 ///     test_depth_non_zero(30);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-02-05"

--- a/src/lazy_merkle_tree.rs
+++ b/src/lazy_merkle_tree.rs
@@ -86,7 +86,6 @@ impl<H: Hasher, Version: VersionMarker> LazyMerkleTree<H, Version> {
 
     /// Creates a new memory mapped file specified by path and creates a tree
     /// with dense prefix of the given depth with initial values
-    #[must_use]
     pub fn new_mmapped_with_dense_prefix_with_init_values(
         depth: usize,
         prefix_depth: usize,
@@ -1736,8 +1735,7 @@ pub mod bench {
         let prefix_depth = depth;
         let empty_value = Field::from(0);
 
-        let initial_values: Vec<ruint::Uint<256, 4>> =
-            (0..(1 << depth)).map(|value| Field::from(value)).collect();
+        let initial_values: Vec<ruint::Uint<256, 4>> = (0..(1 << depth)).map(Field::from).collect();
 
         TreeValues {
             depth,

--- a/src/lazy_merkle_tree.rs
+++ b/src/lazy_merkle_tree.rs
@@ -687,7 +687,6 @@ impl<H: Hasher> Clone for DenseTree<H> {
 
 impl<H: Hasher> DenseTree<H> {
     fn new_with_values(values: &[H::Hash], empty_value: &H::Hash, depth: usize) -> Self {
-        println!("depth: {depth}");
         let leaf_count = 1 << depth;
         let storage_size = 1 << (depth + 1);
         let mut storage = Vec::with_capacity(storage_size);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
+#![warn(clippy::all, clippy::cargo)]
 // TODO: ark-circom and ethers-core pull in a lot of dependencies, some duplicate.
 #![allow(clippy::multiple_crate_versions)]
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -14,7 +14,7 @@ use std::{
 /// Hash types, values and algorithms for a Merkle tree
 pub trait Hasher {
     /// Type of the leaf and node hashes
-    type Hash: Clone + Eq + Serialize + Debug + Send + Sync;
+    type Hash: Clone + Eq + Serialize + Debug + Send + Sync + Sized;
 
     /// Compute the hash of an intermediate node
     fn hash_node(left: &Self::Hash, right: &Self::Hash) -> Self::Hash;

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -14,7 +14,7 @@ use std::{
 /// Hash types, values and algorithms for a Merkle tree
 pub trait Hasher {
     /// Type of the leaf and node hashes
-    type Hash: Clone + Eq + Serialize + Debug + Send + Sync + Sized;
+    type Hash: Clone + Eq + Serialize + Debug + Send + Sync;
 
     /// Compute the hash of an intermediate node
     fn hash_node(left: &Self::Hash, right: &Self::Hash) -> Self::Hash;

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -14,7 +14,7 @@ use std::{
 /// Hash types, values and algorithms for a Merkle tree
 pub trait Hasher {
     /// Type of the leaf and node hashes
-    type Hash: Clone + Eq + Serialize + Debug;
+    type Hash: Clone + Eq + Serialize + Debug + Send + Sync;
 
     /// Compute the hash of an intermediate node
     fn hash_node(left: &Self::Hash, right: &Self::Hash) -> Self::Hash;

--- a/src/protocol/authentication.rs
+++ b/src/protocol/authentication.rs
@@ -14,7 +14,7 @@ pub fn generate_proof(
     let merkle_proof = LazyPoseidonTree::new(depth, Field::from(0))
         .update(0, &identity.commitment())
         .proof(0);
-    return super::generate_proof(identity, &merkle_proof, ext_nullifier_hash, signal_hash);
+    super::generate_proof(identity, &merkle_proof, ext_nullifier_hash, signal_hash)
 }
 
 pub fn verify_proof(
@@ -28,12 +28,12 @@ pub fn verify_proof(
     let root = LazyPoseidonTree::new(depth, Field::from(0))
         .update(0, &id_commitment)
         .root();
-    return super::verify_proof(
+    super::verify_proof(
         root,
         nullifier_hash,
         signal_hash,
         ext_nullifier_hash,
         proof,
         depth,
-    );
+    )
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -269,7 +269,7 @@ mod test {
     #[test_all_depths]
     fn test_proof_serialize(depth: usize) {
         let proof = arb_proof(456, depth);
-        let json = serde_json::to_value(&proof).unwrap();
+        let json = serde_json::to_value(proof).unwrap();
         let valid_values = match depth {
             16 => json!([
                 [


### PR DESCRIPTION
Added `Send + Sync` to Hash. Technically a breaking change but not likely to cause problems.