### PR TITLE
use SPDX identifier for license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "Rust support library for Semaphore"
 keywords = ["worldcoin", "protocol", "signup"]
 categories = ["cryptography"]
 readme = "Readme.md"
-license-file = "mit-license.md"
+license = "MIT"
 
 [workspace]
 members = ["crates/*"]

--- a/crates/semaphore-depth-config/Cargo.toml
+++ b/crates/semaphore-depth-config/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "semaphore-depth-config"
 version = "0.1.0"
+license = "MIT"
 edition = "2021"
 publish = false
 

--- a/crates/semaphore-depth-macros/Cargo.toml
+++ b/crates/semaphore-depth-macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "semaphore-depth-macros"
 version = "0.1.0"
+license = "MIT"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Automated tools like `cargo deny` work better when using the `license` field instead of `license-file`.