### PR TITLE
use cargo workspace inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,27 @@
 [package]
 name = "semaphore"
 version = "0.1.0"
-edition = "2021"
 authors = [
     "Remco Bloemen <remco@worldcoin.org>",
     "Philipp Sippl <philipp@worldcoin.org>",
 ]
-homepage = "https://github.com/worldcoin/semaphore-rs"
-repository = "https://github.com/worldcoin/semaphore-rs"
 description = "Rust support library for Semaphore"
 keywords = ["worldcoin", "protocol", "signup"]
 categories = ["cryptography"]
-readme = "Readme.md"
-license = "MIT"
+
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [workspace]
 members = ["crates/*"]
+
+[workspace.package]
+edition = "2021"
+homepage = "https://github.com/worldcoin/semaphore-rs"
+license = "MIT"
+repository = "https://github.com/worldcoin/semaphore-rs"
 
 [features]
 depth_16 = [

--- a/crates/semaphore-depth-config/Cargo.toml
+++ b/crates/semaphore-depth-config/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "semaphore-depth-config"
 version = "0.1.0"
-license = "MIT"
-edition = "2021"
 publish = false
+
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [features]
 depth_16 = []

--- a/crates/semaphore-depth-macros/Cargo.toml
+++ b/crates/semaphore-depth-macros/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "semaphore-depth-macros"
 version = "0.1.0"
-license = "MIT"
-edition = "2021"
 publish = false
+
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [features]
 depth_16 = ["semaphore-depth-config/depth_16"]


### PR DESCRIPTION
This makes all crates in the project have the `edition`, `repository`, `homepage`, and `license` fields.
It also removes the `readme` field, as the default behavior will already pull in README.md.