### PR TITLE
Dependency review + Cleanup + Allow updating dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,17 @@ env:
   RUST_VERSION: 1.81.0
 
 jobs:
+  dependabot-dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@v4
+        with:
+          base-ref: ${{ inputs.base-ref || github.event.pull_request.base.sha || 'main' }}
+          head-ref: ${{ inputs.head-ref || github.event.pull_request.head.sha || github.ref }}
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ quote = "1.0.26"
 
 # Ark
 ark-bn254 = { version = "=0.4.0" }
-ark-circom = { git = "https://github.com/Dzejkop/circom-compat.git", rev = "625633e", features = [
+ark-circom = { git = "https://github.com/Dzejkop/circom-compat.git", rev = "3b19f79", features = [
     "circom-2",
 ] }
 ark-ec = { version = "0.4.2", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,10 @@ ark-std = { version = "0.4.0", default-features = false, features = [
 ] }
 ark-serialize = { version = "0.4.2", features = ["derive"] }
 
+# Necessary because there's an issue with dependencies in the workspace
+# this has something to do with `net` feature not being enabled in `mio`.
+tokio = "=1.38"
+
 [features]
 default = []
 depth_16 = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,9 @@ tiny-keccak = { version = "2.0.2" }
 tracing-test = "0.2"
 witness = { git = "https://github.com/philsippl/circom-witness-rs" }
 zeroize = "1.6.0"
+memmap2 = "0.9"
+flame = "0.2"
+flamer = "0.5"
 
 # Proc macros
 syn = { version = "2.0.9", features = ["full", "visit-mut", "extra-traits"] }
@@ -77,13 +80,13 @@ quote = "1.0.26"
 
 # Ark
 ark-bn254 = { version = "=0.4.0" }
-ark-circom = { git = "https://github.com/arkworks-rs/circom-compat.git", rev = "f97ac2b", features = [
+ark-circom = { git = "https://github.com/Dzejkop/circom-compat.git", rev = "625633e", features = [
     "circom-2",
 ] }
-ark-ec = { version = "0.4.1", default-features = false, features = [
+ark-ec = { version = "0.4.2", default-features = false, features = [
     "parallel",
 ] }
-ark-ff = { version = "0.4.1", default-features = false, features = [
+ark-ff = { version = "0.4.2", default-features = false, features = [
     "parallel",
     "asm",
 ] }
@@ -92,6 +95,7 @@ ark-relations = { version = "=0.4.0", default-features = false }
 ark-std = { version = "0.4.0", default-features = false, features = [
     "parallel",
 ] }
+ark-serialize = { version = "0.4.2", features = ["derive"] }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,62 +122,63 @@ harness = false
 
 [dependencies]
 # Internal
-ark-zkey = { workspace = true }
-poseidon = { workspace = true }
-hasher = { workspace = true }
-keccak = { workspace = true }
-trees = { workspace = true }
-storage = { workspace = true }
-semaphore-depth-config = { workspace = true }
-semaphore-depth-macros = { workspace = true }
+ark-zkey.workspace = true
+poseidon.workspace = true
+hasher.workspace = true
+keccak.workspace = true
+trees.workspace = true
+storage.workspace = true
+semaphore-depth-config.workspace = true
+semaphore-depth-macros.workspace = true
 
 # 3rd Party
-bincode = { workspace = true }
-bytemuck = { workspace = true }
-color-eyre = { workspace = true }
-ethabi = { workspace = true }
-ethers-core = { workspace = true }
-hex = { workspace = true }
-hex-literal = { workspace = true }
-itertools = { workspace = true }
-mmap-rs = { workspace = true }
-num-bigint = { workspace = true }
-once_cell = { workspace = true }
-rand = { workspace = true }
-rayon = { workspace = true }
-ruint = { workspace = true }
-serde = { workspace = true }
-sha2 = { workspace = true }
-thiserror = { workspace = true }
-tiny-keccak = { workspace = true }
-witness = { workspace = true }
-zeroize = { workspace = true }
+bincode.workspace = true
+bytemuck.workspace = true
+color-eyre.workspace = true
+ethabi.workspace = true
+ethers-core.workspace = true
+hex.workspace = true
+hex-literal.workspace = true
+itertools.workspace = true
+mmap-rs.workspace = true
+num-bigint.workspace = true
+once_cell.workspace = true
+rand.workspace = true
+rayon.workspace = true
+ruint.workspace = true
+serde.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+tiny-keccak.workspace = true
+witness.workspace = true
+zeroize.workspace = true
+tokio.workspace = true
 
 # Ark
-ark-bn254 = { workspace = true }
-ark-circom = { workspace = true }
-ark-ec = { workspace = true }
-ark-ff = { workspace = true }
-ark-groth16 = { workspace = true }
-ark-relations = { workspace = true }
-ark-std = { workspace = true }
+ark-bn254.workspace = true
+ark-circom.workspace = true
+ark-ec.workspace = true
+ark-ff.workspace = true
+ark-groth16.workspace = true
+ark-relations.workspace = true
+ark-std.workspace = true
 
 [dev-dependencies]
-serial_test = { workspace = true }
-criterion = { workspace = true }
-bincode = { workspace = true }
-proptest = { workspace = true }
-rand_chacha = { workspace = true }
-serde_json = { workspace = true }
-tempfile = { workspace = true }
-tiny-keccak = { workspace = true }
-tracing-test = { workspace = true }
+serial_test.workspace = true
+criterion.workspace = true
+bincode.workspace = true
+proptest.workspace = true
+rand_chacha.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+tiny-keccak.workspace = true
+tracing-test.workspace = true
 
 [build-dependencies]
-ark-zkey = { workspace = true }
-color-eyre = { workspace = true }
-reqwest = { workspace = true }
-semaphore-depth-config = { workspace = true }
+ark-zkey.workspace = true
+color-eyre.workspace = true
+reqwest.workspace = true
+semaphore-depth-config.workspace = true
 
 [profile.release]
 codegen-units = 1

--- a/crates/ark-zkey/Cargo.toml
+++ b/crates/ark-zkey/Cargo.toml
@@ -7,15 +7,15 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-color-eyre = { workspace = true }
-memmap2 = { workspace = true }
-flame = { workspace = true }
-flamer = { workspace = true }
+color-eyre.workspace = true
+memmap2.workspace = true
+flame.workspace = true
+flamer.workspace = true
 
-ark-serialize = { workspace = true }
-ark-bn254 = { workspace = true }
-ark-groth16 = { workspace = true }
-ark-circom = { workspace = true }
-ark-relations = { workspace = true }
-ark-ff = { workspace = true }
-ark-ec = { workspace = true }
+ark-serialize.workspace = true
+ark-bn254.workspace = true
+ark-groth16.workspace = true
+ark-circom.workspace = true
+ark-relations.workspace = true
+ark-ff.workspace = true
+ark-ec.workspace = true

--- a/crates/ark-zkey/Cargo.toml
+++ b/crates/ark-zkey/Cargo.toml
@@ -7,15 +7,15 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-color-eyre = "0.6"
-memmap2 = "0.9"
-flame = "0.2"
-flamer = "0.5"
+color-eyre = { workspace = true }
+memmap2 = { workspace = true }
+flame = { workspace = true }
+flamer = { workspace = true }
 
-ark-serialize = { version = "=0.4.1", features = ["derive"] }
-ark-bn254 = { version = "=0.4.0" }
-ark-groth16 = { version = "=0.4.0" }
-ark-circom = { git = "https://github.com/arkworks-rs/circom-compat.git", rev="f97ac2b", features = ["circom-2"] }
-ark-relations = { version = "=0.4.0" }
-ark-ff = { version = "=0.4.1" }
-ark-ec = { version = "=0.4.1" }
+ark-serialize = { workspace = true }
+ark-bn254 = { workspace = true }
+ark-groth16 = { workspace = true }
+ark-circom = { workspace = true }
+ark-relations = { workspace = true }
+ark-ff = { workspace = true }
+ark-ec = { workspace = true }

--- a/crates/ark-zkey/Cargo.toml
+++ b/crates/ark-zkey/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "ark-zkey"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 color-eyre = "0.6"

--- a/crates/ark-zkey/src/lib.rs
+++ b/crates/ark-zkey/src/lib.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
-use std::time::Instant;
 
 use ark_bn254::{Bn254, Fr};
 use ark_circom::read_zkey;
@@ -10,7 +9,6 @@ use ark_groth16::ProvingKey;
 use ark_relations::r1cs::ConstraintMatrices;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use color_eyre::eyre::{Result, WrapErr};
-use memmap2::Mmap;
 
 #[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug, PartialEq)]
 pub struct SerializableProvingKey(pub ProvingKey<Bn254>);
@@ -33,76 +31,19 @@ pub struct SerializableConstraintMatrices<F: Field> {
     pub c: SerializableMatrix<F>,
 }
 
-impl<F: Field> From<Vec<Vec<(F, usize)>>> for SerializableMatrix<F> {
-    fn from(matrix: Vec<Vec<(F, usize)>>) -> Self {
-        SerializableMatrix { data: matrix }
-    }
-}
-
-impl<F: Field> From<SerializableMatrix<F>> for Vec<Vec<(F, usize)>> {
-    fn from(serializable_matrix: SerializableMatrix<F>) -> Self {
-        serializable_matrix.data
-    }
-}
-
-pub fn serialize_proving_key(pk: &SerializableProvingKey) -> Vec<u8> {
-    let mut serialized_data = Vec::new();
-    pk.serialize_compressed(&mut serialized_data)
-        .expect("Serialization failed");
-    serialized_data
-}
-
-pub fn deserialize_proving_key(data: Vec<u8>) -> SerializableProvingKey {
-    SerializableProvingKey::deserialize_compressed_unchecked(&mut &data[..])
-        .expect("Deserialization failed")
-}
-
-pub fn read_arkzkey(
-    arkzkey_path: &str,
-) -> Result<(SerializableProvingKey, SerializableConstraintMatrices<Fr>)> {
-    let now = std::time::Instant::now();
-    let arkzkey_file_path = PathBuf::from(arkzkey_path);
-    let arkzkey_file = File::open(arkzkey_file_path).wrap_err("Failed to open arkzkey file")?;
-    println!("Time to open arkzkey file: {:?}", now.elapsed());
-
-    // Using mmap
-    let now = std::time::Instant::now();
-    let mmap = unsafe { Mmap::map(&arkzkey_file)? };
-    let mut cursor = std::io::Cursor::new(mmap);
-    println!("Time to mmap arkzkey: {:?}", now.elapsed());
-
-    // Was &mut buf_reader
-    let now = std::time::Instant::now();
-    let proving_key = SerializableProvingKey::deserialize_compressed_unchecked(&mut cursor)
-        .wrap_err("Failed to deserialize proving key")?;
-    println!("Time to deserialize proving key: {:?}", now.elapsed());
-
-    let now = std::time::Instant::now();
-    let constraint_matrices =
-        SerializableConstraintMatrices::deserialize_compressed_unchecked(&mut cursor)
-            .wrap_err("Failed to deserialize constraint matrices")?;
-    println!("Time to deserialize matrices: {:?}", now.elapsed());
-
-    Ok((proving_key, constraint_matrices))
-}
-
 // TODO: Return ProvingKey<Bn254>, ConstraintMatrices<Fr>?
 pub fn read_arkzkey_from_bytes(
     arkzkey_bytes: &[u8],
 ) -> Result<(ProvingKey<Bn254>, ConstraintMatrices<Fr>)> {
     let mut cursor = std::io::Cursor::new(arkzkey_bytes);
 
-    let now = std::time::Instant::now();
     let serialized_proving_key =
         SerializableProvingKey::deserialize_compressed_unchecked(&mut cursor)
             .wrap_err("Failed to deserialize proving key")?;
-    println!("Time to deserialize proving key: {:?}", now.elapsed());
 
-    let now = std::time::Instant::now();
     let serialized_constraint_matrices =
         SerializableConstraintMatrices::deserialize_compressed_unchecked(&mut cursor)
             .wrap_err("Failed to deserialize constraint matrices")?;
-    println!("Time to deserialize matrices: {:?}", now.elapsed());
 
     // Get on right form for API
     let proving_key: ProvingKey<Bn254> = serialized_proving_key.0;
@@ -124,8 +65,6 @@ pub fn read_arkzkey_from_bytes(
 pub fn read_proving_key_and_matrices_from_zkey(
     zkey_path: &str,
 ) -> Result<(SerializableProvingKey, SerializableConstraintMatrices<Fr>)> {
-    println!("Reading zkey from: {}", zkey_path);
-    let now = Instant::now();
     let zkey_file_path = PathBuf::from(zkey_path);
     let zkey_file = File::open(zkey_file_path).wrap_err("Failed to open zkey file")?;
 
@@ -133,10 +72,7 @@ pub fn read_proving_key_and_matrices_from_zkey(
 
     let (proving_key, matrices) =
         read_zkey(&mut buf_reader).wrap_err("Failed to read zkey file")?;
-    println!("Time to read zkey: {:?}", now.elapsed());
 
-    println!("Serializing proving key and constraint matrices");
-    let now = Instant::now();
     let serializable_proving_key = SerializableProvingKey(proving_key);
     let serializable_constrain_matrices = SerializableConstraintMatrices {
         num_instance_variables: matrices.num_instance_variables,
@@ -149,10 +85,6 @@ pub fn read_proving_key_and_matrices_from_zkey(
         b: SerializableMatrix { data: matrices.b },
         c: SerializableMatrix { data: matrices.c },
     };
-    println!(
-        "Time to serialize proving key and constraint matrices: {:?}",
-        now.elapsed()
-    );
 
     Ok((serializable_proving_key, serializable_constrain_matrices))
 }

--- a/crates/hasher/Cargo.toml
+++ b/crates/hasher/Cargo.toml
@@ -7,4 +7,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-bytemuck = { workspace = true }
+bytemuck.workspace = true

--- a/crates/keccak/Cargo.toml
+++ b/crates/keccak/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-hasher = { workspace = true }
-tiny-keccak = { workspace = true }
+hasher.workspace = true
+tiny-keccak.workspace = true
 
 [features]
 default = ["sha3"]

--- a/crates/poseidon/Cargo.toml
+++ b/crates/poseidon/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-hasher = { workspace = true }
-ark-bn254 = { workspace = true }
-ark-ff = { workspace = true }
-once_cell = { workspace = true }
-ruint = { workspace = true }
+hasher.workspace = true
+ark-bn254.workspace = true
+ark-ff.workspace = true
+once_cell.workspace = true
+ruint.workspace = true

--- a/crates/semaphore-depth-config/Cargo.toml
+++ b/crates/semaphore-depth-config/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "semaphore-depth-config"
 version = "0.1.0"
-publish = false
-
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/semaphore-depth-macros/Cargo.toml
+++ b/crates/semaphore-depth-macros/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "semaphore-depth-macros"
 version = "0.1.0"
-publish = false
-
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/crates/semaphore-depth-macros/Cargo.toml
+++ b/crates/semaphore-depth-macros/Cargo.toml
@@ -15,8 +15,8 @@ depth_30 = ["semaphore-depth-config/depth_30"]
 proc-macro = true
 
 [dependencies]
-semaphore-depth-config = { workspace = true }
+semaphore-depth-config.workspace = true
 itertools ={ workspace = true }
-syn = { workspace = true }
-proc-macro2 = { workspace = true }
-quote = { workspace = true }
+syn.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-bytemuck = { workspace = true }
-color-eyre = { workspace = true }
-mmap-rs = { workspace = true }
-tempfile = { workspace = true }
+bytemuck.workspace = true
+color-eyre.workspace = true
+mmap-rs.workspace = true
+tempfile.workspace = true

--- a/crates/trees/Cargo.toml
+++ b/crates/trees/Cargo.toml
@@ -8,37 +8,37 @@ repository.workspace = true
 
 [dependencies]
 # Internal
-hasher = { workspace = true }
-storage = { workspace = true }
+hasher.workspace = true
+storage.workspace = true
 
 # 3rd Party
-bytemuck = { workspace = true }
-color-eyre = { workspace = true }
-hex = { workspace = true }
-hex-literal = { workspace = true }
-itertools = { workspace = true }
-mmap-rs = { workspace = true }
-once_cell = { workspace = true }
-rayon = { workspace = true }
-ruint = { workspace = true }
-serde = { workspace = true }
-thiserror = { workspace = true }
+bytemuck.workspace = true
+color-eyre.workspace = true
+hex.workspace = true
+hex-literal.workspace = true
+itertools.workspace = true
+mmap-rs.workspace = true
+once_cell.workspace = true
+rayon.workspace = true
+ruint.workspace = true
+serde.workspace = true
+thiserror.workspace = true
 tiny-keccak = { workspace = true, features = ["sha3"] }
 
 # Ark
-ark-bn254 = { workspace = true }
-ark-circom = { workspace = true }
-ark-ec = { workspace = true }
-ark-ff = { workspace = true }
-ark-groth16 = { workspace = true }
-ark-relations = { workspace = true }
-ark-std = { workspace = true }
+ark-bn254.workspace = true
+ark-circom.workspace = true
+ark-ec.workspace = true
+ark-ff.workspace = true
+ark-groth16.workspace = true
+ark-relations.workspace = true
+ark-std.workspace = true
 
 [dev-dependencies]
-poseidon = { workspace = true }
-keccak = { workspace = true }
+poseidon.workspace = true
+keccak.workspace = true
 
-rand = { workspace = true }
-serial_test = { workspace = true }
-tempfile = { workspace = true }
-test-case = { workspace = true }
+rand.workspace = true
+serial_test.workspace = true
+tempfile.workspace = true
+test-case.workspace = true


### PR DESCRIPTION
This PR:
1. Adds a dependency review Dependabot job
2. Cleans up some unused code
3. Switched circom-compat to a [temporary fork](https://github.com/arkworks-rs/circom-compat/pull/77) that will allow upstream consumers of this library to update their dependencies