### PR TITLE
Fix invalid trait implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ bincode = "1.3.3"
 bytemuck = "1.18"
 color-eyre = "0.6"
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+derive-where = "1"
 ethabi = "18.0.0"
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 hex = "0.4.0"

--- a/crates/trees/Cargo.toml
+++ b/crates/trees/Cargo.toml
@@ -14,6 +14,7 @@ storage.workspace = true
 # 3rd Party
 bytemuck.workspace = true
 color-eyre.workspace = true
+derive-where.workspace = true
 hex.workspace = true
 hex-literal.workspace = true
 itertools.workspace = true

--- a/crates/trees/src/cascading/mod.rs
+++ b/crates/trees/src/cascading/mod.rs
@@ -33,7 +33,6 @@ use self::storage_ops::{sparse_fill_partial_subtree, StorageOps};
 /// Leaves are 0 indexed
 /// 0  1  2  3  4  5  6  7
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CascadingMerkleTree<H, S = Vec<<H as Hasher>::Hash>>
 where
     H: Hasher,
@@ -44,6 +43,64 @@ where
     sparse_column: Vec<H::Hash>,
     storage: S,
     _marker: std::marker::PhantomData<H>,
+}
+
+impl<H, S> Debug for CascadingMerkleTree<H, S>
+where
+    H: Hasher,
+    <H as Hasher>::Hash: Debug,
+    S: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CascadingMerkleTree")
+            .field("depth", &self.depth)
+            .field("root", &self.root)
+            .field("empty_value", &self.empty_value)
+            .field("sparse_column", &self.sparse_column)
+            .field("storage", &self.storage)
+            .finish()
+    }
+}
+
+impl<H, S> Clone for CascadingMerkleTree<H, S>
+where
+    H: Hasher,
+    <H as Hasher>::Hash: Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            depth: self.depth,
+            root: self.root.clone(),
+            empty_value: self.empty_value.clone(),
+            sparse_column: self.sparse_column.clone(),
+            storage: self.storage.clone(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<H, S> PartialEq for CascadingMerkleTree<H, S>
+where
+    H: Hasher,
+    <H as Hasher>::Hash: PartialEq,
+    S: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.depth == other.depth
+            && self.root == other.root
+            && self.empty_value == other.empty_value
+            && self.sparse_column == other.sparse_column
+            && self.storage == other.storage
+    }
+}
+
+impl<H, S> Eq for CascadingMerkleTree<H, S>
+where
+    H: Hasher,
+    <H as Hasher>::Hash: Eq,
+    S: Eq,
+{
 }
 
 impl<H, S> CascadingMerkleTree<H, S>
@@ -477,7 +534,7 @@ mod tests {
 
     pub fn debug_tree<H, S>(tree: &CascadingMerkleTree<H, S>)
     where
-        H: Hasher + std::fmt::Debug,
+        H: Hasher,
         <H as Hasher>::Hash: Debug + Copy,
         S: GenericStorage<H::Hash> + std::fmt::Debug,
     {
@@ -487,7 +544,7 @@ mod tests {
 
     pub fn debug_storage<H, S>(storage: &S)
     where
-        H: Hasher + std::fmt::Debug,
+        H: Hasher,
         <H as Hasher>::Hash: Debug + Copy,
         S: std::ops::Deref<Target = [<H as Hasher>::Hash]> + std::fmt::Debug,
     {

--- a/crates/trees/src/cascading/mod.rs
+++ b/crates/trees/src/cascading/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use bytemuck::Pod;
 use color_eyre::eyre::{ensure, Result};
+use derive_where::derive_where;
 use hasher::Hasher;
 
 use crate::proof::{Branch, Proof};
@@ -33,6 +34,10 @@ use self::storage_ops::{sparse_fill_partial_subtree, StorageOps};
 /// Leaves are 0 indexed
 /// 0  1  2  3  4  5  6  7
 /// ```
+#[derive_where(Clone; <H as Hasher>::Hash: Clone, S: Clone)]
+#[derive_where(PartialEq; <H as Hasher>::Hash: PartialEq, S: PartialEq)]
+#[derive_where(Eq; <H as Hasher>::Hash: Eq, S: Eq)]
+#[derive_where(Debug; <H as Hasher>::Hash: Debug, S: Debug)]
 pub struct CascadingMerkleTree<H, S = Vec<<H as Hasher>::Hash>>
 where
     H: Hasher,
@@ -43,64 +48,6 @@ where
     sparse_column: Vec<H::Hash>,
     storage: S,
     _marker: std::marker::PhantomData<H>,
-}
-
-impl<H, S> Debug for CascadingMerkleTree<H, S>
-where
-    H: Hasher,
-    <H as Hasher>::Hash: Debug,
-    S: Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CascadingMerkleTree")
-            .field("depth", &self.depth)
-            .field("root", &self.root)
-            .field("empty_value", &self.empty_value)
-            .field("sparse_column", &self.sparse_column)
-            .field("storage", &self.storage)
-            .finish()
-    }
-}
-
-impl<H, S> Clone for CascadingMerkleTree<H, S>
-where
-    H: Hasher,
-    <H as Hasher>::Hash: Clone,
-    S: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            depth: self.depth,
-            root: self.root.clone(),
-            empty_value: self.empty_value.clone(),
-            sparse_column: self.sparse_column.clone(),
-            storage: self.storage.clone(),
-            _marker: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<H, S> PartialEq for CascadingMerkleTree<H, S>
-where
-    H: Hasher,
-    <H as Hasher>::Hash: PartialEq,
-    S: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.depth == other.depth
-            && self.root == other.root
-            && self.empty_value == other.empty_value
-            && self.sparse_column == other.sparse_column
-            && self.storage == other.storage
-    }
-}
-
-impl<H, S> Eq for CascadingMerkleTree<H, S>
-where
-    H: Hasher,
-    <H as Hasher>::Hash: Eq,
-    S: Eq,
-{
 }
 
 impl<H, S> CascadingMerkleTree<H, S>

--- a/crates/trees/src/imt/mod.rs
+++ b/crates/trees/src/imt/mod.rs
@@ -9,7 +9,6 @@ use hasher::Hasher;
 use crate::proof::{Branch, Proof};
 
 /// Merkle tree with all leaf and intermediate hashes stored
-#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct MerkleTree<H>
 where
     H: Hasher,
@@ -22,6 +21,51 @@ where
 
     /// Hash values of tree nodes and leaves, breadth first order
     nodes: Vec<H::Hash>,
+}
+
+impl<H> Clone for MerkleTree<H>
+where
+    H: Hasher,
+    <H as Hasher>::Hash: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            depth: self.depth,
+            empty: self.empty.clone(),
+            nodes: self.nodes.clone(),
+        }
+    }
+}
+
+impl<H> PartialEq for MerkleTree<H>
+where
+    H: Hasher,
+    H::Hash: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.depth.eq(&other.depth) && self.empty.eq(&other.empty) && self.nodes.eq(&other.nodes)
+    }
+}
+
+impl<H> Eq for MerkleTree<H>
+where
+    H: Hasher,
+    H::Hash: Eq,
+{
+}
+
+impl<H> Debug for MerkleTree<H>
+where
+    H: Hasher,
+    H::Hash: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MerkleTree")
+            .field("depth", &self.depth)
+            .field("empty", &self.empty)
+            .field("nodes", &self.nodes)
+            .finish()
+    }
 }
 
 /// For a given node index, return the parent node index

--- a/crates/trees/src/imt/mod.rs
+++ b/crates/trees/src/imt/mod.rs
@@ -4,11 +4,16 @@ use std::fmt::Debug;
 use std::iter::{once, repeat, successors};
 
 use bytemuck::Pod;
+use derive_where::derive_where;
 use hasher::Hasher;
 
 use crate::proof::{Branch, Proof};
 
 /// Merkle tree with all leaf and intermediate hashes stored
+#[derive_where(Clone; <H as Hasher>::Hash: Clone)]
+#[derive_where(PartialEq; <H as Hasher>::Hash: PartialEq)]
+#[derive_where(Eq; <H as Hasher>::Hash: Eq)]
+#[derive_where(Debug; <H as Hasher>::Hash: Debug)]
 pub struct MerkleTree<H>
 where
     H: Hasher,
@@ -21,51 +26,6 @@ where
 
     /// Hash values of tree nodes and leaves, breadth first order
     nodes: Vec<H::Hash>,
-}
-
-impl<H> Clone for MerkleTree<H>
-where
-    H: Hasher,
-    <H as Hasher>::Hash: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            depth: self.depth,
-            empty: self.empty.clone(),
-            nodes: self.nodes.clone(),
-        }
-    }
-}
-
-impl<H> PartialEq for MerkleTree<H>
-where
-    H: Hasher,
-    H::Hash: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.depth.eq(&other.depth) && self.empty.eq(&other.empty) && self.nodes.eq(&other.nodes)
-    }
-}
-
-impl<H> Eq for MerkleTree<H>
-where
-    H: Hasher,
-    H::Hash: Eq,
-{
-}
-
-impl<H> Debug for MerkleTree<H>
-where
-    H: Hasher,
-    H::Hash: Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MerkleTree")
-            .field("depth", &self.depth)
-            .field("empty", &self.empty)
-            .field("nodes", &self.nodes)
-            .finish()
-    }
 }
 
 /// For a given node index, return the parent node index

--- a/crates/trees/src/proof.rs
+++ b/crates/trees/src/proof.rs
@@ -1,39 +1,17 @@
 use std::fmt::Debug;
 
+use derive_where::derive_where;
 use hasher::Hasher;
 use serde::{Deserialize, Serialize};
 
 /// Merkle proof path, bottom to top.
+#[derive_where(Clone; <H as Hasher>::Hash: Clone)]
+#[derive_where(PartialEq; <H as Hasher>::Hash: PartialEq)]
+#[derive_where(Eq; <H as Hasher>::Hash: Eq)]
+#[derive_where(Debug; <H as Hasher>::Hash: Debug)]
 pub struct Proof<H>(pub Vec<Branch<H::Hash>>)
 where
     H: Hasher;
-
-impl<H> PartialEq for Proof<H>
-where
-    H: Hasher,
-    H::Hash: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<H> Clone for Proof<H>
-where
-    H: Hasher,
-    <H as Hasher>::Hash: Clone,
-{
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl<H> Eq for Proof<H>
-where
-    H: Hasher,
-    H::Hash: Eq,
-{
-}
 
 /// Element of a Merkle proof
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -89,15 +67,5 @@ impl<T: Debug> Debug for Branch<T> {
             Self::Left(arg0) => f.debug_tuple("Left").field(arg0).finish(),
             Self::Right(arg0) => f.debug_tuple("Right").field(arg0).finish(),
         }
-    }
-}
-
-impl<H> Debug for Proof<H>
-where
-    H: Hasher,
-    H::Hash: Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Proof").field(&self.0).finish()
     }
 }

--- a/crates/trees/src/proof.rs
+++ b/crates/trees/src/proof.rs
@@ -4,7 +4,6 @@ use hasher::Hasher;
 use serde::{Deserialize, Serialize};
 
 /// Merkle proof path, bottom to top.
-#[derive(Clone)]
 pub struct Proof<H>(pub Vec<Branch<H::Hash>>)
 where
     H: Hasher;
@@ -16,6 +15,16 @@ where
 {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
+    }
+}
+
+impl<H> Clone for Proof<H>
+where
+    H: Hasher,
+    <H as Hasher>::Hash: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 


### PR DESCRIPTION
Fixes invalid trait implementations like

```
#[derive(Clone)]
pub struct Proof<H>(pub Vec<Branch<H::Hash>>)
where
    H: Hasher;
```

where `Clone` would only be implemented if the Hasher was Clone. Not if the hash type was clone