### PR TITLE
add warmup for verification method

### DIFF
--- a/crates/semaphore/src/protocol/mod.rs
+++ b/crates/semaphore/src/protocol/mod.rs
@@ -32,6 +32,11 @@ static WITHESS_GRAPH: [Lazy<Graph>; get_supported_depth_count()] = array_for_dep
     })
 });
 
+/// Preloads the ZKEY in memory to skip the lazy loading at first verification
+pub fn warmup_for_verification(tree_depth: usize) {
+    let _zkey = zkey(tree_depth);
+}
+
 /// Helper to merkle proof into a bigint vector
 /// TODO: we should create a From trait for this
 fn merkle_proof_to_vec(proof: &InclusionProof<Poseidon>) -> Vec<Field> {


### PR DESCRIPTION
ZKEY is lazily loaded at first proof/verification which was impacting proof verification service. There were seeing increased latency on the first request after restart which resulted in timeouts and issues down the stack.

This PR adds a "warmup" function that only initialized the ZKEY for a given depth. This function can be ran at the start of the program to reduce the latency.