### PR TITLE
bump reqwest to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ proptest = "1.0"
 rand = { version = "0.8.4", features = ["small_rng"] }
 rand_chacha = "0.3.1"
 rayon = "1.5.1"
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.12", features = ["blocking"] }
 ruint = { version = "1.12.3", features = [
     "rand",
     "bytemuck",


### PR DESCRIPTION
we're actually already using 0.12, this makes it explicit