### PR TITLE
doc: update readme

### DIFF
--- a/crates/semaphore/README.md
+++ b/crates/semaphore/README.md
@@ -7,7 +7,7 @@ Rust support library for using [semaphore](https://github.com/appliedzkp/semapho
 Add this line to your `cargo.toml`:
 
 ```toml
-semaphore = { git = "https://github.com/worldcoin/semaphore-rs" }
+semaphore-rs = { git = "https://github.com/worldcoin/semaphore-rs" }
 ```
 
 ## Building semaphore circuits
@@ -24,7 +24,6 @@ Example as in `src/lib.rs`, run with `cargo test`.
 ```rust,no_run
 use semaphore_rs::{get_supported_depths, hash_to_field, Field, identity::Identity,
                 poseidon_tree::LazyPoseidonTree, protocol::*};
-use num_bigint::BigInt;
 
 // generate identity
 let mut secret = *b"secret";


### PR DESCRIPTION
fix
- the name of the package is `semaphore-rs`
   https://github.com/worldcoin/semaphore-rs/blob/340d4ada82da830b07041cf2185aa6fd1c4e2967/crates/semaphore/Cargo.toml#L2
- the `num_bigint::BigInt` has not been used