### PR TITLE
chore: fix cargo clippy warning

### DIFF
--- a/crates/trees/src/cascading/mod.rs
+++ b/crates/trees/src/cascading/mod.rs
@@ -189,7 +189,7 @@ where
         if index >= storage_len {
             debug_assert!(storage_len.is_power_of_two());
             self.storage
-                .extend(std::iter::repeat(self.empty_value).take(storage_len));
+                .extend(std::iter::repeat_n(self.empty_value, storage_len));
             let subtree = &mut self.storage[storage_len..(storage_len << 1)];
             sparse_fill_partial_subtree::<H>(subtree, &self.sparse_column, 0..(storage_len >> 1));
         }
@@ -390,7 +390,7 @@ where
             let diff = next_power_of_two - storage_len;
 
             self.storage
-                .extend(std::iter::repeat(self.empty_value).take(diff));
+                .extend(std::iter::repeat_n(self.empty_value, diff));
         }
 
         // Represense the power of the first subtree that has been modified

--- a/crates/trees/src/cascading/storage_ops.rs
+++ b/crates/trees/src/cascading/storage_ops.rs
@@ -31,7 +31,7 @@ where
         let base_len = num_leaves.next_power_of_two();
         let storage_size = base_len << 1;
         self.clear();
-        self.extend(std::iter::repeat(*empty_value).take(storage_size));
+        self.extend(std::iter::repeat_n(*empty_value, storage_size));
         let depth = base_len.ilog2();
 
         // We iterate over subsequently larger subtrees

--- a/crates/trees/src/imt/mod.rs
+++ b/crates/trees/src/imt/mod.rs
@@ -1,7 +1,7 @@
 //! Implements basic binary Merkle trees
 
 use std::fmt::Debug;
-use std::iter::{once, repeat, successors};
+use std::iter::{once, successors};
 
 use bytemuck::Pod;
 use derive_where::derive_where;
@@ -73,7 +73,7 @@ where
             .iter()
             .rev()
             .enumerate()
-            .flat_map(|(depth, hash)| repeat(hash).take(1 << depth))
+            .flat_map(|(depth, hash)| std::iter::repeat_n(hash, 1 << depth))
             .cloned();
 
         let nodes = first_node.chain(nodes).collect();

--- a/crates/trees/src/lazy/mod.rs
+++ b/crates/trees/src/lazy/mod.rs
@@ -1,6 +1,6 @@
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::iter::{once, repeat, successors};
+use std::iter::{once, successors};
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -507,7 +507,7 @@ where
             .iter()
             .rev()
             .enumerate()
-            .flat_map(|(depth, value)| repeat(value).take(1 << depth));
+            .flat_map(|(depth, value)| std::iter::repeat_n(value, 1 << depth));
         let padded_values = once(&self.empty_tree_values[0])
             .chain(values)
             .cloned()
@@ -718,11 +718,11 @@ where
         let storage_size = 1 << (depth + 1);
         let mut storage = Vec::with_capacity(storage_size);
 
-        let empties = repeat(empty_value).take(leaf_count);
+        let empties = std::iter::repeat_n(empty_value, leaf_count);
         storage.extend(empties);
         storage.extend_from_slice(values);
         if values.len() < leaf_count {
-            let empties = repeat(empty_value).take(leaf_count - values.len());
+            let empties = std::iter::repeat_n(empty_value, leaf_count - values.len());
             storage.extend(empties);
         }
 


### PR DESCRIPTION
Running cargo clippy reports the following error.

```shell
warning: this `repeat().take()` can be written more concisely
  --> crates/trees/src/cascading/storage_ops.rs:34:21
   |
34 |         self.extend(std::iter::repeat(*empty_value).take(storage_size));
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(*empty_value, storage_size)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n
   = note: `#[warn(clippy::manual_repeat_n)]` on by default

warning: this `repeat().take()` can be written more concisely
   --> crates/trees/src/cascading/mod.rs:192:25
    |
192 |                 .extend(std::iter::repeat(self.empty_value).take(storage_len));
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(self.empty_value, storage_len)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n

warning: this `repeat().take()` can be written more concisely
   --> crates/trees/src/cascading/mod.rs:393:25
    |
393 |                 .extend(std::iter::repeat(self.empty_value).take(diff));
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(self.empty_value, diff)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n

warning: this `repeat().take()` can be written more concisely
  --> crates/trees/src/imt/mod.rs:76:39
   |
76 |             .flat_map(|(depth, hash)| repeat(hash).take(1 << depth))
   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(hash, 1 << depth)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n

warning: this `repeat().take()` can be written more concisely
   --> crates/trees/src/lazy/mod.rs:510:40
    |
510 |             .flat_map(|(depth, value)| repeat(value).take(1 << depth));
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(value, 1 << depth)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n

warning: this `repeat().take()` can be written more concisely
   --> crates/trees/src/lazy/mod.rs:721:23
    |
721 |         let empties = repeat(empty_value).take(leaf_count);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(empty_value, leaf_count)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n

warning: this `repeat().take()` can be written more concisely
   --> crates/trees/src/lazy/mod.rs:725:27
    |
725 |             let empties = repeat(empty_value).take(leaf_count - values.len());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(empty_value, leaf_count - values.len())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n

warning: `semaphore-rs-trees` (lib) generated 7 warnings (run `cargo clippy --fix --lib -p semaphore-rs-trees` to apply 7 suggestions)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 55s
```




This commit resolves the issue.