### PR TITLE
bump alloy-core to 1.0 & create feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ semaphore-rs-depth-macros = { version = "0.4.0", path = "crates/semaphore-depth-
 semaphore-rs-witness = { version = "0.4.0", path = "crates/circom-witness-rs" }
 
 # 3rd Party
-alloy-core = { version = "0.8.12", default-features = false, features = [
+alloy-core = { version = "1.0", default-features = false, features = [
     "sol-types",
 ] }
 bincode = "1.3.3"

--- a/crates/proof/Cargo.toml
+++ b/crates/proof/Cargo.toml
@@ -20,12 +20,12 @@ serde_json.workspace = true
 ark-ec = { workspace = true, optional = true }
 ark-groth16 = { workspace = true, optional = true }
 ark-bn254 = { workspace = true, optional = true }
+alloy-core = { workspace = true, optional = true }
 lazy_static.workspace = true
 getrandom.workspace = true
-alloy-core.workspace = true
 hex.workspace = true
 
 [features]
-default = ["ark"]
+default = ["ark", "packing"]
 ark = ["dep:semaphore-rs-ark-circom", "dep:ark-ec", "dep:ark-groth16", "dep:ark-bn254"]
-
+packing = ["dep:alloy-core"]

--- a/crates/proof/src/lib.rs
+++ b/crates/proof/src/lib.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 mod ark;
 
 pub mod compression;
+
+#[cfg(feature = "packing")]
 pub mod packing;
 
 // Matches the private G1Tup type in ark-circom.

--- a/crates/proof/src/packing.rs
+++ b/crates/proof/src/packing.rs
@@ -39,7 +39,7 @@ impl From<Proof> for PackedProof {
 
 impl From<PackedProof> for Proof {
     fn from(proof: PackedProof) -> Self {
-        let decoded = FixedArray::<Uint<256>, 8>::abi_decode(&proof.0, true).unwrap();
+        let decoded = FixedArray::<Uint<256>, 8>::abi_decode(&proof.0).unwrap();
 
         let a = (decoded[0], decoded[1]);
         let b = ([decoded[2], decoded[3]], [decoded[4], decoded[5]]);

--- a/crates/semaphore/Cargo.toml
+++ b/crates/semaphore/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 semaphore-rs-utils.workspace = true
 semaphore-rs-ark-zkey.workspace = true
 semaphore-rs-ark-circom.workspace = true
-semaphore-rs-proof = { workspace = true, features = ["ark"] }
+semaphore-rs-proof = { workspace = true, features = ["ark", "packing"] }
 semaphore-rs-poseidon.workspace = true
 semaphore-rs-hasher.workspace = true
 semaphore-rs-keccak.workspace = true
@@ -26,7 +26,6 @@ semaphore-rs-depth-macros.workspace = true
 semaphore-rs-witness.workspace = true
 
 # 3rd Party
-alloy-core.workspace = true
 bincode.workspace = true
 bytemuck.workspace = true
 color-eyre.workspace = true


### PR DESCRIPTION
Bumps alloy core to 1.0 and introduces a feature flag (available by default) to be able to turn off feature flags