### PR TITLE
Optimize authentication proofs and restore macro-based depth tests

### DIFF
--- a/crates/semaphore/src/lib.rs
+++ b/crates/semaphore/src/lib.rs
@@ -18,6 +18,8 @@ pub use crate::field::{hash_to_field, Field, MODULUS};
 mod test {
     use std::thread::spawn;
 
+    use semaphore_rs_depth_macros::test_all_depths;
+
     use crate::identity::Identity;
     use crate::poseidon_tree::LazyPoseidonTree;
     use crate::protocol::{generate_nullifier_hash, generate_proof, verify_proof};
@@ -70,6 +72,7 @@ mod test {
         }
     }
 
+    #[test_all_depths]
     fn test_auth_flow(depth: usize) {
         let mut secret = *b"oh so secret";
         let id = Identity::from_secret(&mut secret[..], None);
@@ -98,52 +101,14 @@ mod test {
         assert!(success);
     }
 
-    #[test]
-    #[cfg(feature = "depth_16")]
-    fn test_auth_flow_depth_16() {
-        test_auth_flow(16);
-    }
-
-    #[test]
-    #[cfg(feature = "depth_20")]
-    fn test_auth_flow_depth_20() {
-        test_auth_flow(20);
-    }
-
-    // depth_30 Groth16 proof generation takes >60 s on current CI runners;
-    // correctness at depth_30 is also exercised by test_single / test_parallel.
-    #[test]
-    #[cfg(feature = "depth_30")]
-    #[ignore = "depth_30 proof generation takes >60 s, too slow for unattended CI"]
-    fn test_auth_flow_depth_30() {
-        test_auth_flow(30);
-    }
-
+    #[test_all_depths]
     fn test_single_impl(depth: usize) {
         // Note that rust will still run tests in parallel
         let mut hello = *b"hello";
         test_end_to_end(&mut hello, b"appId", b"xxx", depth);
     }
 
-    #[test]
-    #[cfg(feature = "depth_16")]
-    fn test_single_depth_16() {
-        test_single_impl(16);
-    }
-
-    #[test]
-    #[cfg(feature = "depth_20")]
-    fn test_single_depth_20() {
-        test_single_impl(20);
-    }
-
-    #[test]
-    #[cfg(feature = "depth_30")]
-    #[ignore = "depth_30 proof generation takes >60 s, too slow for unattended CI"]
-    fn test_single_depth_30() {
-        test_single_impl(30);
-    }
-
+    #[test_all_depths]
     fn test_parallel_impl(depth: usize) {
         // Note that this does not guarantee a concurrency issue will be detected.
         // For that we need much more sophisticated static analysis tooling like
@@ -154,24 +119,5 @@ mod test {
         let b = spawn(move || test_end_to_end(&mut b_id, b"test", b"signal", depth));
         a.join().unwrap();
         b.join().unwrap();
-    }
-
-    #[test]
-    #[cfg(feature = "depth_16")]
-    fn test_parallel_depth_16() {
-        test_parallel_impl(16);
-    }
-
-    #[test]
-    #[cfg(feature = "depth_20")]
-    fn test_parallel_depth_20() {
-        test_parallel_impl(20);
-    }
-
-    #[test]
-    #[cfg(feature = "depth_30")]
-    #[ignore = "depth_30 proof generation takes >60 s, too slow for unattended CI"]
-    fn test_parallel_depth_30() {
-        test_parallel_impl(30);
     }
 }

--- a/crates/semaphore/src/protocol/authentication.rs
+++ b/crates/semaphore/src/protocol/authentication.rs
@@ -1,9 +1,30 @@
 use crate::{
     identity::Identity,
-    poseidon_tree::PoseidonTree,
     protocol::{Proof, ProofError},
     Field,
 };
+use semaphore_rs_poseidon::poseidon::hash2;
+use semaphore_rs_trees::{Branch, InclusionProof};
+
+fn empty_hashes(depth: usize) -> Vec<Field> {
+    let mut empty = Vec::with_capacity(depth);
+    let mut hash = Field::from(0);
+
+    for _ in 0..depth {
+        empty.push(hash);
+        hash = hash2(hash, hash);
+    }
+
+    empty
+}
+
+fn authentication_merkle_proof(depth: usize) -> InclusionProof<semaphore_rs_poseidon::Poseidon> {
+    InclusionProof(empty_hashes(depth).into_iter().map(Branch::Left).collect())
+}
+
+fn authentication_root(depth: usize, id_commitment: Field) -> Field {
+    empty_hashes(depth).into_iter().fold(id_commitment, hash2)
+}
 
 pub fn generate_proof(
     depth: usize,
@@ -11,10 +32,7 @@ pub fn generate_proof(
     ext_nullifier_hash: Field,
     signal_hash: Field,
 ) -> Result<Proof, ProofError> {
-    let mut tree = PoseidonTree::new(depth, Field::from(0));
-    tree.set(0, identity.commitment());
-    // proof(0) always returns Some: leaf 0 < 2^depth for any usize depth
-    let merkle_proof = tree.proof(0).expect("leaf index 0 is always in-bounds");
+    let merkle_proof = authentication_merkle_proof(depth);
     super::generate_proof(identity, &merkle_proof, ext_nullifier_hash, signal_hash)
 }
 
@@ -26,9 +44,7 @@ pub fn verify_proof(
     ext_nullifier_hash: Field,
     proof: &Proof,
 ) -> Result<bool, ProofError> {
-    let mut tree = PoseidonTree::new(depth, Field::from(0));
-    tree.set(0, id_commitment);
-    let root = tree.root();
+    let root = authentication_root(depth, id_commitment);
     super::verify_proof(
         root,
         nullifier_hash,
@@ -41,20 +57,15 @@ pub fn verify_proof(
 
 #[cfg(test)]
 mod tests {
+    use semaphore_rs_depth_macros::test_all_depths;
+
     use crate::{hash_to_field, identity::Identity, protocol::generate_nullifier_hash};
 
     use super::*;
 
     /// Validates the generate/verify round-trip for the authentication API.
-    ///
-    /// We test at depth 16 only: the logic is depth-agnostic and depth-30
-    /// proof generation takes >60 s, which blows the CI time budget.
-    /// Depth-20 and depth-30 coverage is provided by the existing
-    /// `test_auth_flow`, `test_single`, and `test_parallel` integration tests.
-    #[test]
-    #[cfg(feature = "depth_16")]
-    fn test_round_trip() {
-        let depth = 16;
+    #[test_all_depths]
+    fn test_round_trip(depth: usize) {
         let mut secret = *b"test secret seed";
         let id = Identity::from_secret(&mut secret, None);
 


### PR DESCRIPTION
## Summary
- avoid building a pre-allocated IMT in authentication proof generation and verification
- compute the authentication Merkle proof/root directly for the always-empty tree with leaf 0 populated
- restore `test_all_depths` usage for the semaphore authentication, single, and parallel tests

## Testing
- cargo test -p semaphore-rs authentication::tests::test_round_trip --features depth_16
- cargo test -p semaphore-rs test_auth_flow_depth_16 --features depth_16
- cargo test -p semaphore-rs protocol::authentication::tests::test_round_trip_depth_16 --features depth_16
- cargo test -p semaphore-rs test_single_impl_depth_16 --features depth_16